### PR TITLE
[Bug] Progress bar is displayed in case of NoArgumentException

### DIFF
--- a/DirectoryTool/Program.cs
+++ b/DirectoryTool/Program.cs
@@ -13,7 +13,6 @@ namespace DirectoryTool
         {
             try
             {
-                InfoService.InitializeProgressMessageThread();
                 if (args.Length == 0)
                     throw new WrongCommandLineArguments("Arguments are not specified.");
                 switch (args[0].Substring(1))

--- a/DirectoryTool/Services/SavingService.cs
+++ b/DirectoryTool/Services/SavingService.cs
@@ -14,6 +14,7 @@ namespace DirectoryTool.Services
     {
         public void Save(string folderPath, string fileName)
         {
+            InfoService.InitializeProgressMessageThread();
             folderPath = Path.GetFullPath(folderPath);
             string rootFolderName = folderPath.Split(Path.DirectorySeparatorChar).Last();
             if (String.IsNullOrEmpty(fileName))


### PR DESCRIPTION
[[Bug] Progress bar is displayed in case of NoArgumentException](https://github.com/KristiSik/directorytool/projects/1#card-11282671) fixed.